### PR TITLE
fix(service): fix typeidx of different modules in typeck

### DIFF
--- a/crates/service/src/binder.rs
+++ b/crates/service/src/binder.rs
@@ -131,14 +131,14 @@ fn create_symbol_table(db: &dyn SymbolTablesCtx, uri: InternUri) -> Arc<SymbolTa
     let mut symbols = Vec::with_capacity(2);
     let mut blocks = vec![];
     let mut exports = vec![];
-    root.children().for_each(|module| {
+    root.children().enumerate().for_each(|(module_id, module)| {
         symbols.push(Symbol {
             green: module.green().into(),
             key: SymbolKey::new(&module),
             region: SymbolKey::new(&root),
             kind: SymbolKind::Module,
             idx: Idx {
-                num: None,
+                num: Some(module_id as u32),
                 name: None,
             },
         });
@@ -658,6 +658,12 @@ impl SymbolTable {
                         .find(|symbol| symbol.key == block.ref_key)
                 }),
         )
+    }
+
+    pub fn find_module(&self, module_id: u32) -> Option<&Symbol> {
+        self.symbols
+            .iter()
+            .find(|symbol| symbol.kind == SymbolKind::Module && symbol.idx.num == Some(module_id))
     }
 }
 

--- a/crates/service/src/checker/mod.rs
+++ b/crates/service/src/checker/mod.rs
@@ -27,7 +27,7 @@ pub fn check(service: &LanguageService, uri: InternUri) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::with_capacity(4);
     syntax::check(service, &mut diagnostics, uri, &line_index, &root);
     multi_modules::check(&mut diagnostics, &line_index, &root);
-    root.children().for_each(|module| {
+    root.children().enumerate().for_each(|(module_id, module)| {
         implicit_module::check(
             &mut diagnostics,
             config.lint.implicit_module,
@@ -42,6 +42,7 @@ pub fn check(service: &LanguageService, uri: InternUri) -> Vec<Diagnostic> {
                     uri,
                     &line_index,
                     &symbol_table,
+                    module_id as u32,
                     &node,
                 );
                 unreachable::check(
@@ -60,6 +61,7 @@ pub fn check(service: &LanguageService, uri: InternUri) -> Vec<Diagnostic> {
                     uri,
                     &line_index,
                     &symbol_table,
+                    module_id as u32,
                     &node,
                 );
                 unreachable::check(

--- a/crates/service/src/types_analyzer/mod.rs
+++ b/crates/service/src/types_analyzer/mod.rs
@@ -67,14 +67,21 @@ pub(crate) trait TypesAnalyzerCtx: SyntaxTreeCtx + SymbolTablesCtx {
     fn def_types(&self, uri: InternUri) -> Arc<Vec<DefType>>;
 
     #[salsa::memoized]
-    fn value_type_matches(&self, uri: InternUri, sub: ValType, sup: ValType) -> bool;
+    fn value_type_matches(
+        &self,
+        uri: InternUri,
+        module_id: u32,
+        sub: ValType,
+        sup: ValType,
+    ) -> bool;
 }
 
 fn value_type_matches(
     db: &dyn TypesAnalyzerCtx,
     uri: InternUri,
+    module_id: u32,
     sub: ValType,
     sup: ValType,
 ) -> bool {
-    sub.matches(&sup, db, uri)
+    sub.matches(&sup, db, uri, module_id)
 }


### PR DESCRIPTION
Currently when there're multiple modules in a single WAT document, resolving typeidx in subsequent modules for type checking will always read from the first module, which is wrong.

This PR added additional information which is module id for searching corresponding module. The reason why we don't use module's symbol key is that symbol key is actually a syntax node pointer. If node range is changed, pointer will also be changed, while module id is stable and better for memoization of incremental computation.