### PR TITLE
refactor(service): reduce memory usage of `resolved` in symbol table

### DIFF
--- a/crates/service/src/binder.rs
+++ b/crates/service/src/binder.rs
@@ -11,7 +11,9 @@ use std::{
     borrow::Borrow,
     fmt,
     hash::{BuildHasher, Hash},
+    num::NonZeroU32,
     ops::Deref,
+    slice,
 };
 use wat_syntax::{
     AmberNode, GreenNode, NodeOrToken, SyntaxKind, SyntaxNode, SyntaxNodePtr, TextRange,
@@ -21,7 +23,7 @@ use wat_syntax::{
 #[derive(Clone, Debug, PartialEq, Eq, salsa::SalsaValue)]
 pub(crate) struct SymbolTable<'db> {
     pub symbols: Symbols<'db>,
-    pub resolved: FxHashMap<SymbolKey, SymbolKey>,
+    resolved: Resolved,
     pub modules: FxHashMap<SymbolKey, ModuleDefSymbols>,
     type_nodes: FxHashMap<SymbolKey, (GreenNode, TextRange)>,
 }
@@ -121,13 +123,13 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
         }
     }
     fn search_def<'a, 'db>(
-        defs: &'a [(SymbolKey, Option<InternIdent<'db>>)],
+        defs: &'a [(SymbolKey, Option<InternIdent<'db>>, u32)],
         idx: Idx,
-    ) -> Option<&'a (SymbolKey, Option<InternIdent<'db>>)> {
+    ) -> Option<&'a (SymbolKey, Option<InternIdent<'db>>, u32)> {
         idx.num.and_then(|num| defs.get(num as usize)).or_else(|| {
             idx.name.and_then(|name| {
                 defs.iter()
-                    .find(|(_, def_name)| def_name.is_some_and(|def_name| def_name == name))
+                    .find(|(_, def_name, _)| def_name.is_some_and(|def_name| def_name == name))
             })
         })
     }
@@ -189,12 +191,14 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
         indices: HashTable::new(),
         build_hasher: FxBuildHasher,
     };
-    let mut resolved = FxHashMap::default();
+    let mut resolved = Vec::new();
     let mut modules = FxHashMap::with_capacity_and_hasher(1, FxBuildHasher);
     let mut type_nodes = FxHashMap::default();
     let bump = Bump::new();
+    let mut pre_resolved = BumpHashMap::new_in(&bump);
     root.children().enumerate().for_each(|(module_id, module)| {
         let module_key = module.into();
+        let module_index = symbols.values.len() as u32;
         symbols.insert(Symbol {
             green: module.green().clone(),
             key: module_key,
@@ -229,7 +233,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
         let mut tags = BumpVec::new_in(&bump);
         let mut datas = BumpVec::new_in(&bump);
         let mut elems = BumpVec::new_in(&bump);
-        let mut indirect_params = BumpVec::new_in(&bump);
+        let mut indirect_params = BumpVec::<(SymbolKey, _, _)>::new_in(&bump);
 
         let mut node_stack = BumpVec::with_capacity_in(8, &bump);
         node_stack.push((module, 0));
@@ -241,7 +245,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                             let func_idx = func_idx_gen.pull();
                             let symbol = create_module_level_symbol(db, node, func_idx, SymbolKind::Func, module_key);
                             let func_key = symbol.key;
-                            funcs.push((func_key, symbol.idx.name));
+                            funcs.push((func_key, symbol.idx.name, symbols.values.len() as u32));
                             symbols.insert(symbol);
                             locals.clear();
                             local_idx_gen.reset();
@@ -268,7 +272,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                 let key = node.into();
                                 let idx = local_idx_gen.pull();
                                 let name = InternIdent::new(db, ident.text());
-                                locals.push((key, Some(name)));
+                                locals.push((key, Some(name), symbols.values.len() as u32));
                                 symbols.insert(Symbol {
                                     key,
                                     green: node.green().clone(),
@@ -284,10 +288,10 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                     },
                                 });
                             } else {
-                                symbols.extend(node.children_by_kind(ValType::can_cast).map(|val_type| {
+                                node.children_by_kind(ValType::can_cast).for_each(|val_type| {
                                     let key = val_type.into();
-                                    locals.push((key, None));
-                                    Symbol {
+                                    locals.push((key, None, symbols.values.len() as u32));
+                                    symbols.insert(Symbol {
                                         key,
                                         green: val_type.green().clone(),
                                         region,
@@ -296,8 +300,8 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                             num: Some(local_idx_gen.pull()),
                                             name: None,
                                         },
-                                    }
-                                }));
+                                    });
+                                });
                             }
                         }
                         SyntaxKind::LOCAL => {
@@ -306,7 +310,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                 let key = node.into();
                                 let idx = local_idx_gen.pull();
                                 let name = InternIdent::new(db, ident.text());
-                                locals.push((key, Some(name)));
+                                locals.push((key, Some(name), symbols.values.len() as u32));
                                 symbols.insert(Symbol {
                                     key,
                                     green: node.green().clone(),
@@ -318,10 +322,10 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                     },
                                 });
                             } else {
-                                symbols.extend(node.children_by_kind(ValType::can_cast).map(|val_type| {
+                                node.children_by_kind(ValType::can_cast).for_each(|val_type| {
                                     let key = val_type.into();
-                                    locals.push((key, None));
-                                    Symbol {
+                                    locals.push((key, None, symbols.values.len() as u32));
+                                    symbols.insert(Symbol {
                                         key,
                                         green: val_type.green().clone(),
                                         region: func_key,
@@ -330,15 +334,15 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                             num: Some(local_idx_gen.pull()),
                                             name: None,
                                         },
-                                    }
-                                }));
+                                    })
+                                });
                             }
                         }
                         SyntaxKind::TYPE_DEF => {
                             let type_idx = type_idx_gen.pull();
                             let symbol = create_module_level_symbol(db, node, type_idx, SymbolKind::Type, module_key);
                             let type_def_key = symbol.key;
-                            types.push((type_def_key, symbol.idx.name));
+                            types.push((type_def_key, symbol.idx.name, symbols.values.len() as u32));
                             symbols.insert(symbol);
                         }
                         SyntaxKind::FUNC_TYPE => {
@@ -364,7 +368,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                 let key = node.into();
                                 let idx = field_idx_gen.pull();
                                 let name = InternIdent::new(db, ident.text());
-                                fields.push((key, Some(name)));
+                                fields.push((key, Some(name), symbols.values.len() as u32));
                                 symbols.insert(Symbol {
                                     key,
                                     green: node.green().clone(),
@@ -376,10 +380,10 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                     },
                                 });
                             } else {
-                                symbols.extend(node.children_by_kind(SyntaxKind::FIELD_TYPE).map(|field_type| {
+                                node.children_by_kind(SyntaxKind::FIELD_TYPE).for_each(|field_type| {
                                     let key = field_type.into();
-                                    fields.push((key, None));
-                                    Symbol {
+                                    fields.push((key, None, symbols.values.len() as u32));
+                                    symbols.insert(Symbol {
                                         key,
                                         green: field_type.green().clone(),
                                         region: type_def_key,
@@ -388,14 +392,14 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                             num: Some(field_idx_gen.pull()),
                                             name: None,
                                         },
-                                    }
-                                }));
+                                    });
+                                });
                             }
                         }
                         SyntaxKind::MODULE_FIELD_GLOBAL => {
                             let idx = global_idx_gen.pull();
                             let symbol = create_module_level_symbol(db, node, idx, SymbolKind::GlobalDef, module_key);
-                            globals.push((symbol.key, symbol.idx.name));
+                            globals.push((symbol.key, symbol.idx.name, symbols.values.len() as u32));
                             symbols.insert(symbol);
                         }
                         SyntaxKind::PLAIN_INSTR => 'instr: {
@@ -421,17 +425,19 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                         break 'instr;
                                     };
                                     let region = (*func).into();
-                                    symbols.extend(node.children().filter_map(|node| {
-                                        create_ref_symbol(db, node, region, SymbolKind::LocalRef).inspect(|symbol| {
-                                            if let Some((def_key, _)) = search_def(&locals, symbol.idx) {
-                                                resolved.insert(symbol.key, *def_key);
+                                    node.children()
+                                        .filter_map(|node| create_ref_symbol(db, node, region, SymbolKind::LocalRef))
+                                        .for_each(|symbol| {
+                                            let index = symbols.values.len() as u32;
+                                            if let Some((def_key, ..)) = search_def(&locals, symbol.idx) {
+                                                pre_resolved.insert(index, *def_key);
                                             } else if let Some(num) = symbol.idx.num
                                                 && let Some(idx) = helpers::syntax::pick_type_idx_from_func(*func)
                                             {
-                                                indirect_params.push((idx.into(), symbol.key, num));
+                                                indirect_params.push((idx.into(), index, num));
                                             }
-                                        })
-                                    }));
+                                            symbols.insert(symbol);
+                                        });
                                 }
                                 Some("global.get" | "global.set") => {
                                     symbols.extend(node.children().filter_map(|node| {
@@ -451,7 +457,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                                 if let Some(def_key) =
                                                     resolve_block_def(&symbol, &symbols, &node_stack, false)
                                                 {
-                                                    resolved.insert(symbol.key, def_key);
+                                                    pre_resolved.insert(symbols.values.len() as u32, def_key);
                                                 }
                                                 symbols.insert(symbol);
                                             });
@@ -721,19 +727,19 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                         SyntaxKind::MODULE_FIELD_MEMORY => {
                             let idx = mem_idx_gen.pull();
                             let symbol = create_module_level_symbol(db, node, idx, SymbolKind::MemoryDef, module_key);
-                            memories.push((symbol.key, symbol.idx.name));
+                            memories.push((symbol.key, symbol.idx.name, symbols.values.len() as u32));
                             symbols.insert(symbol);
                         }
                         SyntaxKind::MODULE_FIELD_TABLE => {
                             let idx = table_idx_gen.pull();
                             let symbol = create_module_level_symbol(db, node, idx, SymbolKind::TableDef, module_key);
-                            tables.push((symbol.key, symbol.idx.name));
+                            tables.push((symbol.key, symbol.idx.name, symbols.values.len() as u32));
                             symbols.insert(symbol);
                         }
                         SyntaxKind::MODULE_FIELD_TAG => {
                             let idx = tag_idx_gen.pull();
                             let symbol = create_module_level_symbol(db, node, idx, SymbolKind::TagDef, module_key);
-                            tags.push((symbol.key, symbol.idx.name));
+                            tags.push((symbol.key, symbol.idx.name, symbols.values.len() as u32));
                             symbols.insert(symbol);
                         }
                         SyntaxKind::EXTERN_IDX_GLOBAL => {
@@ -786,7 +792,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                         let idx = func_idx_gen.pull();
                                         let symbol =
                                             create_extern_type_symbol(db, node, idx, SymbolKind::Func, module_key, ty);
-                                        funcs.push((symbol.key, symbol.idx.name));
+                                        funcs.push((symbol.key, symbol.idx.name, symbols.values.len() as u32));
                                         type_nodes.insert(symbol.key, (ty.green().clone(), ty.text_range()));
                                         symbols.insert(symbol);
                                     }
@@ -800,7 +806,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                             module_key,
                                             ty,
                                         );
-                                        globals.push((symbol.key, symbol.idx.name));
+                                        globals.push((symbol.key, symbol.idx.name, symbols.values.len() as u32));
                                         type_nodes.insert(symbol.key, (ty.green().clone(), ty.text_range()));
                                         symbols.insert(symbol);
                                     }
@@ -814,7 +820,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                             module_key,
                                             ty,
                                         );
-                                        memories.push((symbol.key, symbol.idx.name));
+                                        memories.push((symbol.key, symbol.idx.name, symbols.values.len() as u32));
                                         type_nodes.insert(symbol.key, (ty.green().clone(), ty.text_range()));
                                         symbols.insert(symbol);
                                     }
@@ -828,7 +834,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                             module_key,
                                             ty,
                                         );
-                                        tables.push((symbol.key, symbol.idx.name));
+                                        tables.push((symbol.key, symbol.idx.name, symbols.values.len() as u32));
                                         type_nodes.insert(symbol.key, (ty.green().clone(), ty.text_range()));
                                         symbols.insert(symbol);
                                     }
@@ -842,7 +848,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                             module_key,
                                             ty,
                                         );
-                                        tags.push((symbol.key, symbol.idx.name));
+                                        tags.push((symbol.key, symbol.idx.name, symbols.values.len() as u32));
                                         type_nodes.insert(symbol.key, (ty.green().clone(), ty.text_range()));
                                         symbols.insert(symbol);
                                     }
@@ -852,7 +858,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                         SyntaxKind::MODULE_FIELD_DATA => {
                             let idx = data_idx_gen.pull();
                             let symbol = create_module_level_symbol(db, node, idx, SymbolKind::DataDef, module_key);
-                            datas.push((symbol.key, symbol.idx.name));
+                            datas.push((symbol.key, symbol.idx.name, symbols.values.len() as u32));
                             symbols.insert(symbol);
                         }
                         SyntaxKind::MODULE_FIELD_ELEM
@@ -860,7 +866,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                         {
                             let idx = elem_idx_gen.pull();
                             let symbol = create_module_level_symbol(db, node, idx, SymbolKind::ElemDef, module_key);
-                            elems.push((symbol.key, symbol.idx.name));
+                            elems.push((symbol.key, symbol.idx.name, symbols.values.len() as u32));
                             symbols.insert(symbol);
                         }
                         SyntaxKind::MEM_USE => {
@@ -892,7 +898,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                     .and_then(|node| create_ref_symbol(db, node, region, SymbolKind::BlockRef))
                             {
                                 if let Some(def_key) = resolve_block_def(&symbol, &symbols, &node_stack, true) {
-                                    resolved.insert(symbol.key, def_key);
+                                    pre_resolved.insert(symbols.values.len() as u32, def_key);
                                 }
                                 symbols.insert(symbol);
                             }
@@ -905,7 +911,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                     .and_then(|node| create_ref_symbol(db, node, region, SymbolKind::BlockRef))
                             {
                                 if let Some(def_key) = resolve_block_def(&symbol, &symbols, &node_stack, true) {
-                                    resolved.insert(symbol.key, def_key);
+                                    pre_resolved.insert(symbols.values.len() as u32, def_key);
                                 }
                                 symbols.insert(symbol);
                             }
@@ -923,7 +929,7 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
                                 && let Some(symbol) = create_ref_symbol(db, index, region, SymbolKind::BlockRef)
                             {
                                 if let Some(def_key) = resolve_block_def(&symbol, &symbols, &node_stack, false) {
-                                    resolved.insert(symbol.key, def_key);
+                                    pre_resolved.insert(symbols.values.len() as u32, def_key);
                                 }
                                 symbols.insert(symbol);
                             }
@@ -944,111 +950,109 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
             }
         }
 
-        resolved.extend(symbols.iter().filter_map(|symbol| {
-            let defs = match symbol.kind {
-                SymbolKind::Call => {
-                    if symbol.region != module_key {
-                        return None;
+        resolved.reserve(symbols.values.len() - module_index as usize);
+        resolved.extend(
+            symbols
+                .values
+                .get(module_index as usize..)
+                .into_iter()
+                .flatten()
+                .map(|symbol| match symbol.kind {
+                    SymbolKind::Call => search_def(&funcs, symbol.idx).and_then(|(.., index)| NonZeroU32::new(*index)),
+                    SymbolKind::LocalRef | SymbolKind::BlockRef => symbols
+                        .get_index_of(symbol.key)
+                        .and_then(|index| pre_resolved.get(&index))
+                        .and_then(|key| symbols.get_index_of(key))
+                        .and_then(NonZeroU32::new),
+                    SymbolKind::TypeUse => {
+                        search_def(&types, symbol.idx).and_then(|(.., index)| NonZeroU32::new(*index))
                     }
-                    &funcs
-                }
-                SymbolKind::TypeUse => {
-                    if symbol.region != module_key {
-                        return None;
+                    SymbolKind::GlobalRef => {
+                        search_def(&globals, symbol.idx).and_then(|(.., index)| NonZeroU32::new(*index))
                     }
-                    &types
-                }
-                SymbolKind::GlobalRef => {
-                    if symbol.region != module_key {
-                        return None;
+                    SymbolKind::MemoryRef => {
+                        search_def(&memories, symbol.idx).and_then(|(.., index)| NonZeroU32::new(*index))
                     }
-                    &globals
-                }
-                SymbolKind::MemoryRef => {
-                    if symbol.region != module_key {
-                        return None;
+                    SymbolKind::TableRef => {
+                        search_def(&tables, symbol.idx).and_then(|(.., index)| NonZeroU32::new(*index))
                     }
-                    &memories
-                }
-                SymbolKind::TableRef => {
-                    if symbol.region != module_key {
-                        return None;
+                    SymbolKind::FieldRef => symbols
+                        .get(symbol.region)
+                        .and_then(|type_use| search_def(&types, type_use.idx))
+                        .and_then(|(struct_def_key, ..)| fields.get(struct_def_key))
+                        .and_then(|fields| search_def(fields, symbol.idx))
+                        .and_then(|(.., index)| NonZeroU32::new(*index)),
+                    SymbolKind::TagRef => search_def(&tags, symbol.idx).and_then(|(.., index)| NonZeroU32::new(*index)),
+                    SymbolKind::DataRef => {
+                        search_def(&datas, symbol.idx).and_then(|(.., index)| NonZeroU32::new(*index))
                     }
-                    &tables
-                }
-                SymbolKind::FieldRef => {
-                    let type_use = symbols.get(symbol.region)?;
-                    if type_use.region != module_key {
-                        return None;
+                    SymbolKind::ElemRef => {
+                        search_def(&elems, symbol.idx).and_then(|(.., index)| NonZeroU32::new(*index))
                     }
-                    let (struct_def_key, _) = search_def(&types, type_use.idx)?;
-                    fields.get(struct_def_key)?
-                }
-                SymbolKind::TagRef => {
-                    if symbol.region != module_key {
-                        return None;
-                    }
-                    &tags
-                }
-                SymbolKind::DataRef => {
-                    if symbol.region != module_key {
-                        return None;
-                    }
-                    &datas
-                }
-                SymbolKind::ElemRef => {
-                    if symbol.region != module_key {
-                        return None;
-                    }
-                    &elems
-                }
-                _ => return None,
-            };
-            search_def(defs, symbol.idx).map(|(key, _)| (symbol.key, *key))
-        }));
+                    _ => None,
+                }),
+        );
 
         // replace struct fields' region with their actual region
-        symbols.values.iter_mut().for_each(|symbol| {
-            if symbol.kind == SymbolKind::FieldRef
-                && let Some(def_key) = resolved.get(&symbol.region)
-            {
-                symbol.region = *def_key;
+        BumpVec::from_iter_in(
+            symbols.values.iter().enumerate().filter_map(|(i, symbol)| {
+                if symbol.kind == SymbolKind::FieldRef
+                    && let Some(struct_ref_index) = symbols.get_index_of(symbol.region)
+                    && let Some(struct_def_index) = resolved.get(struct_ref_index as usize).and_then(|index| *index)
+                    && let Some(struct_def) = symbols.values.get(struct_def_index.get() as usize)
+                {
+                    Some((i, struct_def.key))
+                } else {
+                    None
+                }
+            }),
+            &bump,
+        )
+        .into_iter()
+        .for_each(|(i, key)| {
+            if let Some(symbol) = symbols.values.get_mut(i) {
+                symbol.region = key;
             }
         });
 
         // bind parameters that are defined via type use like `(type 0)`
-        resolved.reserve(indirect_params.len());
-        indirect_params
-            .into_iter()
-            .for_each(|(type_use_key, param_ref_key, idx)| {
-                if let Some(def_symbol) = resolved.get(&type_use_key).and_then(|type_def_key| {
+        indirect_params.into_iter().for_each(|(type_use_key, param_ref, idx)| {
+            if let Some((index, _)) = symbols
+                .get_index_of(type_use_key)
+                .and_then(|index| resolved.get(index as usize))
+                .and_then(|index| *index)
+                .and_then(|index| symbols.values.get(index.get() as usize))
+                .and_then(|type_def| {
                     symbols
                         .iter()
-                        .filter(|symbol| symbol.kind == SymbolKind::Param && &symbol.region == type_def_key)
+                        .enumerate()
+                        .filter(|(_, symbol)| symbol.kind == SymbolKind::Param && symbol.region == type_def.key)
                         .nth(idx as usize)
-                }) {
-                    resolved.insert(param_ref_key, def_symbol.key);
-                }
-            });
+                })
+                && let Some(param_def) = resolved.get_mut(param_ref as usize)
+            {
+                *param_def = NonZeroU32::new(index as u32);
+            }
+        });
 
         modules.insert(
             module_key,
             ModuleDefSymbols {
-                funcs: funcs.into_iter().map(|(key, _)| key).collect(),
-                types: types.into_iter().map(|(key, _)| key).collect(),
-                globals: globals.into_iter().map(|(key, _)| key).collect(),
-                memories: memories.into_iter().map(|(key, _)| key).collect(),
-                tables: tables.into_iter().map(|(key, _)| key).collect(),
-                tags: tags.into_iter().map(|(key, _)| key).collect(),
-                datas: datas.into_iter().map(|(key, _)| key).collect(),
-                elems: elems.into_iter().map(|(key, _)| key).collect(),
+                funcs: funcs.into_iter().map(|(key, ..)| key).collect(),
+                types: types.into_iter().map(|(key, ..)| key).collect(),
+                globals: globals.into_iter().map(|(key, ..)| key).collect(),
+                memories: memories.into_iter().map(|(key, ..)| key).collect(),
+                tables: tables.into_iter().map(|(key, ..)| key).collect(),
+                tags: tags.into_iter().map(|(key, ..)| key).collect(),
+                datas: datas.into_iter().map(|(key, ..)| key).collect(),
+                elems: elems.into_iter().map(|(key, ..)| key).collect(),
             },
         );
     });
 
     SymbolTable {
         symbols,
-        resolved,
+        resolved: resolved.into_boxed_slice(),
         modules,
         type_nodes,
     }
@@ -1056,7 +1060,16 @@ fn create_symbol_table<'db>(db: &'db dyn salsa::Database, document: Document) ->
 
 impl<'db> SymbolTable<'db> {
     pub fn find_def(&'db self, key: SymbolKey) -> Option<&'db Symbol<'db>> {
-        self.resolved.get(&key).and_then(|def_key| self.symbols.get(def_key))
+        self.symbols
+            .get_index_of(key)
+            .and_then(|index| self.find_def_index(index as usize))
+            .and_then(|index| self.symbols.values.get(index as usize))
+    }
+    fn find_def_index(&self, ref_index: usize) -> Option<u32> {
+        self.resolved
+            .get(ref_index)
+            .and_then(|index| *index)
+            .map(|index| index.get())
     }
 
     pub fn find_def_by_idx(&'db self, idx: Idx<'db>, kind: SymbolKind, module: SymbolKey) -> Option<&'db Symbol<'db>> {
@@ -1101,48 +1114,42 @@ impl<'db> SymbolTable<'db> {
         def_symbol: &Symbol<'db>,
         with_decl: bool,
     ) -> impl Iterator<Item = &Symbol<'db>> {
-        debug_assert_ne!(def_symbol.kind, SymbolKind::BlockDef);
-        self.symbols.iter().filter(move |symbol| {
-            if symbol.kind == def_symbol.kind {
-                with_decl && symbol == &def_symbol
-            } else if IdxKind::from(symbol.kind) == IdxKind::from(def_symbol.kind) {
-                self.resolved
-                    .get(&symbol.key)
-                    .is_some_and(|def_key| def_key == &def_symbol.key)
-            } else {
-                false
-            }
-        })
+        self.find_references(self.symbols.get_index_of(def_symbol.key), with_decl)
     }
-
     pub fn find_references_on_ref(
         &self,
         ref_symbol: &Symbol<'db>,
         with_decl: bool,
     ) -> impl Iterator<Item = &Symbol<'db>> {
-        debug_assert_ne!(ref_symbol.kind, SymbolKind::BlockRef);
-        let def_key = self.resolved.get(&ref_symbol.key);
-        self.symbols.iter().filter(move |symbol| {
-            if symbol.kind == ref_symbol.kind {
+        let def_index = self
+            .symbols
+            .get_index_of(ref_symbol.key)
+            .and_then(|index| self.find_def_index(index as usize));
+        self.find_references(def_index, with_decl).filter(|symbol| {
+            if symbol.kind == SymbolKind::LocalRef {
+                // Special case for params defined in type definition, not function.
+                // Only consider params in a same function.
                 symbol.region == ref_symbol.region
-                    && self.resolved.get(&symbol.key).zip(def_key).is_some_and(|(a, b)| a == b)
-            } else if IdxKind::from(symbol.kind) == IdxKind::from(ref_symbol.kind) {
-                with_decl && def_key.is_some_and(|def_key| def_key == &symbol.key)
             } else {
-                false
+                true
             }
         })
     }
-
-    pub fn find_block_references(&self, def_key: SymbolKey, with_decl: bool) -> impl Iterator<Item = &Symbol<'db>> {
-        if with_decl { self.symbols.get(def_key) } else { None }
-            .into_iter()
-            .chain(
-                self.resolved
-                    .iter()
-                    .filter(move |(_, key)| *key == &def_key)
-                    .filter_map(|(key, _)| self.symbols.get(key)),
-            )
+    fn find_references(&self, def_index: Option<u32>, with_decl: bool) -> impl Iterator<Item = &Symbol<'db>> {
+        self.resolved
+            .iter()
+            .enumerate()
+            .filter(move |(symbol_index, resolved_def_index)| {
+                if let Some(def_index) = def_index {
+                    let is_def = with_decl && *symbol_index == def_index as usize;
+                    let is_ref =
+                        resolved_def_index.is_some_and(|resolved_def_index| resolved_def_index.get() == def_index);
+                    is_def || is_ref
+                } else {
+                    false
+                }
+            })
+            .filter_map(|(symbol_index, _)| self.symbols.values.get(symbol_index))
     }
 
     pub fn find_module(&self, module_id: u32) -> Option<&Symbol<'db>> {
@@ -1164,6 +1171,16 @@ impl<'db> SymbolTable<'db> {
             .get(&symbol.key)
             .map(|(green, range)| AmberNode::new(green, range.start()))
             .unwrap_or(symbol.amber())
+    }
+
+    pub fn iter_may_resolved(&self) -> slice::Iter<'_, Option<NonZeroU32>> {
+        self.resolved.iter()
+    }
+    pub fn iter_resolved(&self) -> impl Iterator<Item = (u32, u32)> {
+        self.resolved
+            .iter()
+            .enumerate()
+            .filter_map(|(i, index)| index.map(|index| (i as u32, index.get())))
     }
 }
 #[salsa::tracked]
@@ -1340,14 +1357,23 @@ impl<'db> Symbols<'db> {
     where
         Q: Borrow<SymbolKey>,
     {
+        self.get_index_of(key).and_then(|i| self.values.get(i as usize))
+    }
+    pub fn get_index(&self, index: u32) -> Option<&Symbol<'db>> {
+        self.values.get(index as usize)
+    }
+    fn get_index_of<Q>(&self, key: Q) -> Option<u32>
+    where
+        Q: Borrow<SymbolKey>,
+    {
         let key = *key.borrow();
         self.indices
             .find(self.build_hasher.hash_one(key), |i| {
                 self.values.get(*i as usize).is_some_and(|symbol| symbol.key == key)
             })
-            .and_then(|i| self.values.get(*i as usize))
+            .copied()
     }
-    pub fn iter(&self) -> std::slice::Iter<'_, Symbol<'db>> {
+    pub fn iter(&self) -> slice::Iter<'_, Symbol<'db>> {
         self.values.iter()
     }
     fn insert(&mut self, symbol: Symbol<'db>) {
@@ -1384,6 +1410,19 @@ impl fmt::Debug for Symbols<'_> {
             .finish()
     }
 }
+
+/// Slice that records about resolving "use" to "definition".
+///
+/// Items are in the same order of symbols, so an index in this slice is equivalent to the index in symbols.
+///
+/// Item type of this slice is `Option`, and there're three kinds of semantics.
+/// - `Some`: a use can be resolved to a definition;
+/// - `None`: a use can't be resolved to a definition, a.k.a. undefined;
+/// - `None`: not applicable, which is the case for a definition itself.
+///
+/// Invariant: index of a definition can never be zero, since `symbols[0]` always corresponds to the first module.
+/// Leveraging this, we can use `NonZeroU32` to get smaller type size.
+type Resolved = Box<[Option<NonZeroU32>]>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ModuleDefSymbols {

--- a/crates/service/src/binder.rs
+++ b/crates/service/src/binder.rs
@@ -1416,9 +1416,9 @@ impl fmt::Debug for Symbols<'_> {
 /// Items are in the same order of symbols, so an index in this slice is equivalent to the index in symbols.
 ///
 /// Item type of this slice is `Option`, and there're three kinds of semantics.
-/// - `Some`: a use can be resolved to a definition;
-/// - `None`: a use can't be resolved to a definition, a.k.a. undefined;
-/// - `None`: not applicable, which is the case for a definition itself.
+/// - `Some(def_index)`: a use can be resolved to a definition;
+/// - `None` for a ref-kind symbol: a use can't be resolved to a definition, a.k.a. undefined;
+/// - `None` for a def-kind symbol: not applicable.
 ///
 /// Invariant: index of a definition can never be zero, since `symbols[0]` always corresponds to the first module.
 /// Leveraging this, we can use `NonZeroU32` to get smaller type size.

--- a/crates/service/src/checker/block_type.rs
+++ b/crates/service/src/checker/block_type.rs
@@ -11,9 +11,8 @@ pub fn check(ctx: &DiagnosticCtx, node: AmberNode) -> Option<Diagnostic> {
         .and_then(|type_use| type_use.children_by_kind(SyntaxKind::INDEX).next())?;
     if ctx
         .symbol_table
-        .resolved
-        .get(&index.into())
-        .and_then(|key| ctx.def_types.get(key))
+        .find_def(index.into())
+        .and_then(|symbol| ctx.def_types.get(&symbol.key))
         .is_some_and(|def_type| !matches!(def_type.comp, CompositeType::Func(..)))
     {
         Some(Diagnostic {

--- a/crates/service/src/checker/cont_type.rs
+++ b/crates/service/src/checker/cont_type.rs
@@ -7,8 +7,8 @@ const DIAGNOSTIC_CODE: &str = "cont-type";
 pub fn check(ctx: &DiagnosticCtx, node: AmberNode) -> Option<Diagnostic> {
     let index = node.children_by_kind(SyntaxKind::INDEX).next()?;
     let ref_symbol = ctx.symbol_table.symbols.get(SymbolKey::from(index))?;
-    let def_key = ctx.symbol_table.resolved.get(&ref_symbol.key)?;
-    if matches!(ctx.def_types.get(def_key)?.comp, CompositeType::Func(..)) {
+    let def_symbol = ctx.symbol_table.find_def(ref_symbol.key)?;
+    if matches!(ctx.def_types.get(&def_symbol.key)?.comp, CompositeType::Func(..)) {
         None
     } else {
         Some(Diagnostic {
@@ -16,7 +16,7 @@ pub fn check(ctx: &DiagnosticCtx, node: AmberNode) -> Option<Diagnostic> {
             code: DIAGNOSTIC_CODE.into(),
             message: format!("type `{}` must be a function type", ref_symbol.idx.render(ctx.db)),
             related_information: Some(vec![RelatedInformation {
-                range: def_key.text_range(),
+                range: def_symbol.key.text_range(),
                 message: format!("type `{}` defined here", ref_symbol.idx.render(ctx.db)),
             }]),
             ..Default::default()

--- a/crates/service/src/checker/deprecated.rs
+++ b/crates/service/src/checker/deprecated.rs
@@ -41,9 +41,8 @@ pub fn check(
         })
         .filter_map(|symbol| {
             symbol_table
-                .resolved
-                .get(&symbol.key)
-                .and_then(|def_key| deprecation.get(def_key))
+                .find_def(symbol.key)
+                .and_then(|def_symbol| deprecation.get(&def_symbol.key))
                 .map(|reason| Diagnostic {
                     range: symbol.key.text_range(),
                     severity,

--- a/crates/service/src/checker/packing.rs
+++ b/crates/service/src/checker/packing.rs
@@ -82,10 +82,10 @@ fn find_struct_field<'db>(
     instr: AmberNode,
 ) -> Option<(&'db StorageType<'db>, &'db Symbol<'db>)> {
     let mut immediates = instr.children_by_kind(SyntaxKind::IMMEDIATE);
-    let struct_def_key = ctx.symbol_table.resolved.get(&immediates.next()?.into())?;
+    let struct_def = ctx.symbol_table.find_def(immediates.next()?.into())?;
     let field_ref_symbol = ctx.symbol_table.symbols.get(SymbolKey::from(immediates.next()?))?;
     if let Some(CompositeType::Struct(Fields(fields))) =
-        ctx.def_types.get(struct_def_key).map(|def_type| &def_type.comp)
+        ctx.def_types.get(&struct_def.key).map(|def_type| &def_type.comp)
     {
         fields
             .iter()
@@ -101,7 +101,7 @@ fn find_array<'db>(ctx: &'db DiagnosticCtx, instr: AmberNode) -> Option<(&'db St
     let ref_symbol = ctx.symbol_table.symbols.get(ref_key)?;
     if let Some(CompositeType::Array(Some(FieldType { storage, .. }))) = ctx
         .def_types
-        .get(ctx.symbol_table.resolved.get(&ref_key)?)
+        .get(&ctx.symbol_table.find_def(ref_key)?.key)
         .map(|def_type| &def_type.comp)
     {
         Some((storage, ref_symbol))

--- a/crates/service/src/checker/tag_type.rs
+++ b/crates/service/src/checker/tag_type.rs
@@ -11,9 +11,8 @@ pub fn check(diagnostics: &mut Vec<Diagnostic>, ctx: &DiagnosticCtx, node: Amber
     if let Some(index) = type_use.children_by_kind(SyntaxKind::INDEX).next()
         && ctx
             .symbol_table
-            .resolved
-            .get(&index.into())
-            .and_then(|def_key| ctx.def_types.get(def_key))
+            .find_def(index.into())
+            .and_then(|def_symbol| ctx.def_types.get(&def_symbol.key))
             .is_some_and(|def_type| !matches!(def_type.comp, CompositeType::Func(..)))
     {
         diagnostics.push(Diagnostic {

--- a/crates/service/src/checker/type_misuse.rs
+++ b/crates/service/src/checker/type_misuse.rs
@@ -598,9 +598,8 @@ pub fn check(
                 }
                 if let Some(diagnostic) = ctx
                     .symbol_table
-                    .resolved
-                    .get(&immediate.into())
-                    .and_then(|key| ctx.def_types.get(key))
+                    .find_def(immediate.into())
+                    .and_then(|symbol| ctx.def_types.get(&symbol.key))
                     .and_then(|def_type| def_type.comp.as_func())
                     .and_then(|sig| check_return_call_result_type(ctx, node, immediate, &sig.results))
                 {

--- a/crates/service/src/checker/undef.rs
+++ b/crates/service/src/checker/undef.rs
@@ -8,7 +8,8 @@ pub fn check(db: &dyn salsa::Database, diagnostics: &mut Vec<Diagnostic>, symbol
         symbol_table
             .symbols
             .iter()
-            .filter(|symbol| match symbol.kind {
+            .zip(symbol_table.iter_may_resolved())
+            .filter(|(symbol, resolved)| match symbol.kind {
                 SymbolKind::Module
                 | SymbolKind::Func
                 | SymbolKind::Param
@@ -32,9 +33,9 @@ pub fn check(db: &dyn salsa::Database, diagnostics: &mut Vec<Diagnostic>, symbol
                 | SymbolKind::BlockRef
                 | SymbolKind::TagRef
                 | SymbolKind::DataRef
-                | SymbolKind::ElemRef => !symbol_table.resolved.contains_key(&symbol.key),
+                | SymbolKind::ElemRef => resolved.is_none(),
             })
-            .map(|symbol| Diagnostic {
+            .map(|(symbol, _)| Diagnostic {
                 range: symbol.key.text_range(),
                 code: DIAGNOSTIC_CODE.into(),
                 message: format!("cannot find {} `{}` in this scope", symbol.kind, symbol.idx.render(db)),

--- a/crates/service/src/checker/uninit.rs
+++ b/crates/service/src/checker/uninit.rs
@@ -119,9 +119,8 @@ fn detect_uninit(
             "local.get" => {
                 if let Some(immediate) = instr.children_by_kind(SyntaxKind::IMMEDIATE).next()
                     && symbol_table
-                        .resolved
-                        .get(&immediate.into())
-                        .is_some_and(|key| *key == def_key)
+                        .find_def(immediate.into())
+                        .is_some_and(|symbol| symbol.key == def_key)
                     && !mark.r#in.get()
                 {
                     Some(immediate.into())
@@ -132,9 +131,8 @@ fn detect_uninit(
             "local.set" | "local.tee" => {
                 if let Some(immediate) = instr.children_by_kind(SyntaxKind::IMMEDIATE).next()
                     && symbol_table
-                        .resolved
-                        .get(&immediate.into())
-                        .is_some_and(|key| *key == def_key)
+                        .find_def(immediate.into())
+                        .is_some_and(|symbol| symbol.key == def_key)
                 {
                     *mark.r#in.get_mut() = true;
                 }
@@ -169,8 +167,8 @@ impl BlockMark {
                         instr
                             .children_by_kind(SyntaxKind::IMMEDIATE)
                             .next()
-                            .and_then(|immediate| symbol_table.resolved.get(&immediate.into()))
-                            .is_some_and(|key| *key == def_key)
+                            .and_then(|immediate| symbol_table.find_def(immediate.into()))
+                            .is_some_and(|symbol| symbol.key == def_key)
                     }),
             ),
         }

--- a/crates/service/src/checker/unread.rs
+++ b/crates/service/src/checker/unread.rs
@@ -109,9 +109,8 @@ fn detect_unread(
                     && last.is_some()
                     && let Some(immediate) = instr.children_by_kind(SyntaxKind::IMMEDIATE).next()
                     && symbol_table
-                        .resolved
-                        .get(&immediate.into())
-                        .is_some_and(|key| *key == def_key)
+                        .find_def(immediate.into())
+                        .is_some_and(|symbol| symbol.key == def_key)
                 {
                     *last = None;
                 }
@@ -119,9 +118,8 @@ fn detect_unread(
             Some("local.set" | "local.tee") => {
                 if let Some(immediate) = instr.children_by_kind(SyntaxKind::IMMEDIATE).next()
                     && symbol_table
-                        .resolved
-                        .get(&immediate.into())
-                        .is_some_and(|key| *key == def_key)
+                        .find_def(immediate.into())
+                        .is_some_and(|symbol| symbol.key == def_key)
                 {
                     set.push(Some(immediate.into()));
                 }
@@ -157,9 +155,8 @@ impl BlockMark {
                     if !kill
                         && let Some(immediate) = instr.children_by_kind(SyntaxKind::IMMEDIATE).next()
                         && symbol_table
-                            .resolved
-                            .get(&immediate.into())
-                            .is_some_and(|key| *key == def_key)
+                            .find_def(immediate.into())
+                            .is_some_and(|symbol| symbol.key == def_key)
                     {
                         r#gen = true;
                     }
@@ -167,9 +164,8 @@ impl BlockMark {
                 Some("local.set" | "local.tee") => {
                     if let Some(immediate) = instr.children_by_kind(SyntaxKind::IMMEDIATE).next()
                         && symbol_table
-                            .resolved
-                            .get(&immediate.into())
-                            .is_some_and(|key| *key == def_key)
+                            .find_def(immediate.into())
+                            .is_some_and(|symbol| symbol.key == def_key)
                     {
                         kill = true;
                     }

--- a/crates/service/src/checker/unused.rs
+++ b/crates/service/src/checker/unused.rs
@@ -24,39 +24,48 @@ pub fn check(
         LintLevel::Warn => DiagnosticSeverity::Warning,
         LintLevel::Deny => DiagnosticSeverity::Error,
     };
-    let used = BumpHashSet::from_iter_in(symbol_table.resolved.values().copied(), bump);
-    diagnostics.extend(symbol_table.symbols.iter().filter_map(|symbol| match symbol.kind {
-        SymbolKind::Func
-        | SymbolKind::Local
-        | SymbolKind::Type
-        | SymbolKind::GlobalDef
-        | SymbolKind::MemoryDef
-        | SymbolKind::TableDef
-        | SymbolKind::FieldDef
-        | SymbolKind::TagDef
-        | SymbolKind::DataDef
-        | SymbolKind::ElemDef => {
-            if used.contains(&symbol.key) || has_export(symbol) || is_prefixed_with_underscore(db, symbol) {
-                None
-            } else {
-                let range = helpers::syntax::infer_def_poi(symbol.amber());
-                Some(report(db, range, severity, symbol))
-            }
-        }
-        SymbolKind::Param => {
-            if used.contains(&symbol.key)
-                || is_prefixed_with_underscore(db, symbol)
-                || imports.contains(&symbol.region)
-                || symbol.region.kind() == SyntaxKind::TYPE_DEF
-            {
-                None
-            } else {
-                let range = helpers::syntax::infer_def_poi(symbol.amber());
-                Some(report(db, range, severity, symbol))
-            }
-        }
-        _ => None,
-    }));
+    let used = BumpHashSet::from_iter_in(
+        symbol_table.iter_resolved().map(|(_, def_index)| def_index as usize),
+        bump,
+    );
+    diagnostics.extend(
+        symbol_table
+            .symbols
+            .iter()
+            .enumerate()
+            .filter_map(|(i, symbol)| match symbol.kind {
+                SymbolKind::Func
+                | SymbolKind::Local
+                | SymbolKind::Type
+                | SymbolKind::GlobalDef
+                | SymbolKind::MemoryDef
+                | SymbolKind::TableDef
+                | SymbolKind::FieldDef
+                | SymbolKind::TagDef
+                | SymbolKind::DataDef
+                | SymbolKind::ElemDef => {
+                    if used.contains(&i) || has_export(symbol) || is_prefixed_with_underscore(db, symbol) {
+                        None
+                    } else {
+                        let range = helpers::syntax::infer_def_poi(symbol.amber());
+                        Some(report(db, range, severity, symbol))
+                    }
+                }
+                SymbolKind::Param => {
+                    if used.contains(&i)
+                        || is_prefixed_with_underscore(db, symbol)
+                        || imports.contains(&symbol.region)
+                        || symbol.region.kind() == SyntaxKind::TYPE_DEF
+                    {
+                        None
+                    } else {
+                        let range = helpers::syntax::infer_def_poi(symbol.amber());
+                        Some(report(db, range, severity, symbol))
+                    }
+                }
+                _ => None,
+            }),
+    );
 }
 
 fn is_prefixed_with_underscore(db: &dyn salsa::Database, symbol: &Symbol) -> bool {

--- a/crates/service/src/checker/useless_catch.rs
+++ b/crates/service/src/checker/useless_catch.rs
@@ -20,12 +20,12 @@ pub fn check(diagnostics: &mut Vec<Diagnostic>, ctx: &DiagnosticCtx, node: Amber
     let mut matches = FxHashMap::<_, AmberNode>::default();
     node.children_by_kind(Cat::can_cast).for_each(|cat| match cat.kind() {
         SyntaxKind::CATCH => {
-            if let Some(def_key) = cat
+            if let Some(def_symbol) = cat
                 .children_by_kind(SyntaxKind::INDEX)
                 .next()
-                .and_then(|index| ctx.symbol_table.resolved.get(&index.into()))
+                .and_then(|index| ctx.symbol_table.find_def(index.into()))
             {
-                let matched = match (matches.get(def_key), &default_match) {
+                let matched = match (matches.get(&def_symbol.key), &default_match) {
                     (Some(catch), Some(catch_all)) => {
                         if catch.text_range().start() < catch_all.text_range().start() {
                             catch
@@ -36,7 +36,7 @@ pub fn check(diagnostics: &mut Vec<Diagnostic>, ctx: &DiagnosticCtx, node: Amber
                     (Some(catch), None) => catch,
                     (None, Some(catch_all)) => catch_all,
                     (None, None) => {
-                        matches.insert(def_key, cat);
+                        matches.insert(def_symbol.key, cat);
                         return;
                     }
                 };

--- a/crates/service/src/features/call_hierarchy.rs
+++ b/crates/service/src/features/call_hierarchy.rs
@@ -79,21 +79,24 @@ impl LanguageService {
         let deprecation = deprecation::get_deprecation(self, document);
         let callee_def_range = line_index.convert(params.item.range)?;
         let mut items = symbol_table
-            .resolved
-            .iter()
-            .filter_map(|(ref_key, def_key)| {
-                if def_key.text_range() == callee_def_range {
-                    Some(ref_key)
+            .iter_resolved()
+            .filter_map(|(ref_index, def_index)| {
+                if symbol_table
+                    .symbols
+                    .get_index(def_index)
+                    .is_some_and(|symbol| symbol.key.text_range() == callee_def_range)
+                {
+                    symbol_table.symbols.get_index(ref_index)
                 } else {
                     None
                 }
             })
-            .filter_map(|call_key| {
+            .filter_map(|call| {
                 symbol_table
                     .symbols
                     .iter()
                     .find(|symbol| {
-                        symbol.kind == SymbolKind::Func && symbol.key.text_range().contains_range(call_key.text_range())
+                        symbol.kind == SymbolKind::Func && symbol.key.text_range().contains_range(call.key.text_range())
                     })
                     .and_then(|symbol| {
                         Some(CallHierarchyIncomingCall {
@@ -115,7 +118,7 @@ impl LanguageService {
                                 selection_range: line_index.convert(helpers::syntax::infer_def_poi(symbol.amber()))?,
                                 data: None,
                             },
-                            from_ranges: vec![line_index.convert(call_key.text_range())?],
+                            from_ranges: vec![line_index.convert(call.key.text_range())?],
                         })
                     })
             })

--- a/crates/service/src/features/completion.rs
+++ b/crates/service/src/features/completion.rs
@@ -731,9 +731,9 @@ fn get_cmp_list(
                 let func_key = SymbolKey::from(&func);
                 let preferred_type = guess_preferred_type(db, document, token);
                 let param_region = if let Some(type_use) = helpers::syntax::pick_type_idx_from_func(func.amber())
-                    && let Some(type_def) = symbol_table.resolved.get(&type_use.into())
+                    && let Some(type_def) = symbol_table.find_def(type_use.into())
                 {
-                    *type_def
+                    type_def.key
                 } else {
                     func_key
                 };
@@ -1013,9 +1013,8 @@ fn get_cmp_list(
             CmpCtx::Field(struct_ref_key) => {
                 let def_types = types_analyzer::get_def_types(db, document);
                 if let Some(CompositeType::Struct(Fields(fields))) = symbol_table
-                    .resolved
-                    .get(&struct_ref_key)
-                    .and_then(|key| def_types.get(key))
+                    .find_def(struct_ref_key)
+                    .and_then(|symbol| def_types.get(&symbol.key))
                     .map(|def_type| &def_type.comp)
                 {
                     items.extend(fields.iter().map(|(ty, idx)| {

--- a/crates/service/src/features/definition.rs
+++ b/crates/service/src/features/definition.rs
@@ -1,6 +1,6 @@
 use crate::{
     LanguageService,
-    binder::{SymbolKey, SymbolTable},
+    binder::{SymbolKey, SymbolKind, SymbolTable},
     helpers::{self, LineIndexExt},
 };
 use lspt::{Declaration, DeclarationParams, Definition, DefinitionParams, Location, TypeDefinitionParams};
@@ -14,19 +14,35 @@ impl LanguageService {
         let position = line_index.convert(params.position)?;
         let symbol_table = SymbolTable::of(self, document);
         symbol_table
-            .resolved
-            .keys()
-            .fold::<Option<&SymbolKey>, _>(None, |acc, ref_key| {
+            .symbols
+            .iter()
+            .filter(|symbol| {
+                matches!(
+                    symbol.kind,
+                    SymbolKind::Call
+                        | SymbolKind::LocalRef
+                        | SymbolKind::TypeUse
+                        | SymbolKind::GlobalRef
+                        | SymbolKind::MemoryRef
+                        | SymbolKind::TableRef
+                        | SymbolKind::FieldRef
+                        | SymbolKind::BlockRef
+                        | SymbolKind::TagRef
+                        | SymbolKind::DataRef
+                        | SymbolKind::ElemRef
+                )
+            })
+            .fold::<Option<SymbolKey>, _>(None, |acc, ref_symbol| {
                 // find deepest ref-symbol node
-                if ref_key.text_range().contains_inclusive(position)
-                    && acc.is_none_or(|acc| acc.text_range().contains_range(ref_key.text_range()))
+                if ref_symbol.key.text_range().contains_inclusive(position)
+                    && acc.is_none_or(|acc| acc.text_range().contains_range(ref_symbol.key.text_range()))
                 {
-                    Some(ref_key)
+                    Some(ref_symbol.key)
                 } else {
                     acc
                 }
             })
-            .and_then(|ref_key| symbol_table.find_def(*ref_key))
+            .and_then(|ref_key| symbol_table.find_def(ref_key))
             .and_then(|symbol| line_index.convert(helpers::syntax::infer_def_poi(symbol.amber())))
             .map(|range| {
                 Definition::Location(Location {
@@ -43,19 +59,35 @@ impl LanguageService {
         let position = line_index.convert(params.position)?;
         let symbol_table = SymbolTable::of(self, document);
         symbol_table
-            .resolved
-            .keys()
-            .fold::<Option<&SymbolKey>, _>(None, |acc, ref_key| {
+            .symbols
+            .iter()
+            .filter(|symbol| {
+                matches!(
+                    symbol.kind,
+                    SymbolKind::Call
+                        | SymbolKind::LocalRef
+                        | SymbolKind::TypeUse
+                        | SymbolKind::GlobalRef
+                        | SymbolKind::MemoryRef
+                        | SymbolKind::TableRef
+                        | SymbolKind::FieldRef
+                        | SymbolKind::BlockRef
+                        | SymbolKind::TagRef
+                        | SymbolKind::DataRef
+                        | SymbolKind::ElemRef
+                )
+            })
+            .fold::<Option<SymbolKey>, _>(None, |acc, ref_symbol| {
                 // find deepest ref-symbol node
-                if ref_key.text_range().contains_inclusive(position)
-                    && acc.is_none_or(|acc| acc.text_range().contains_range(ref_key.text_range()))
+                if ref_symbol.key.text_range().contains_inclusive(position)
+                    && acc.is_none_or(|acc| acc.text_range().contains_range(ref_symbol.key.text_range()))
                 {
-                    Some(ref_key)
+                    Some(ref_symbol.key)
                 } else {
                     acc
                 }
             })
-            .and_then(|ref_key| symbol_table.find_def(*ref_key))
+            .and_then(|ref_key| symbol_table.find_def(ref_key))
             .and_then(|symbol| {
                 symbol
                     .amber()

--- a/crates/service/src/features/document_highlight.rs
+++ b/crates/service/src/features/document_highlight.rs
@@ -53,6 +53,7 @@ impl LanguageService {
                             | SymbolKind::GlobalDef
                             | SymbolKind::MemoryDef
                             | SymbolKind::TableDef
+                            | SymbolKind::BlockDef
                             | SymbolKind::FieldDef
                             | SymbolKind::TagDef
                             | SymbolKind::DataDef
@@ -70,6 +71,7 @@ impl LanguageService {
                             | SymbolKind::GlobalRef
                             | SymbolKind::MemoryRef
                             | SymbolKind::TableRef
+                            | SymbolKind::BlockRef
                             | SymbolKind::FieldRef
                             | SymbolKind::TagRef
                             | SymbolKind::DataRef
@@ -81,22 +83,6 @@ impl LanguageService {
                                     })
                                     .collect(),
                             ),
-                            SymbolKind::BlockDef => Some(
-                                symbol_table
-                                    .find_block_references(key, true)
-                                    .filter_map(|symbol| {
-                                        create_symbol_highlight(symbol, &root, line_index, symbol_table)
-                                    })
-                                    .collect(),
-                            ),
-                            SymbolKind::BlockRef => symbol_table.resolved.get(&key).map(|def_key| {
-                                symbol_table
-                                    .find_block_references(*def_key, true)
-                                    .filter_map(|symbol| {
-                                        create_symbol_highlight(symbol, &root, line_index, symbol_table)
-                                    })
-                                    .collect()
-                            }),
                         }
                     } else {
                         let text = token.text();

--- a/crates/service/src/features/references.rs
+++ b/crates/service/src/features/references.rs
@@ -54,6 +54,7 @@ impl LanguageService {
             | SymbolKind::GlobalDef
             | SymbolKind::MemoryDef
             | SymbolKind::TableDef
+            | SymbolKind::BlockDef
             | SymbolKind::FieldDef
             | SymbolKind::TagDef
             | SymbolKind::DataDef
@@ -73,6 +74,7 @@ impl LanguageService {
             | SymbolKind::GlobalRef
             | SymbolKind::MemoryRef
             | SymbolKind::TableRef
+            | SymbolKind::BlockRef
             | SymbolKind::FieldRef
             | SymbolKind::TagRef
             | SymbolKind::DataRef
@@ -86,30 +88,6 @@ impl LanguageService {
                     })
                     .collect(),
             ),
-            SymbolKind::BlockDef => Some(
-                symbol_table
-                    .find_block_references(key, params.context.include_declaration)
-                    .filter_map(|symbol| line_index.convert(helpers::syntax::infer_def_poi(symbol.amber())))
-                    .map(|range| Location {
-                        uri: uri.clone(),
-                        range,
-                    })
-                    .collect(),
-            ),
-            SymbolKind::BlockRef => symbol_table.resolved.get(&key).map(|def_key| {
-                symbol_table
-                    .find_block_references(*def_key, params.context.include_declaration)
-                    .filter_map(|symbol| line_index.convert(helpers::syntax::infer_def_poi(symbol.amber())))
-                    .map(|range| Location {
-                        uri: uri.clone(),
-                        range,
-                    })
-                    .collect()
-            }),
         }
-        .map(|mut references: Vec<_>| {
-            references.sort_unstable_by_key(|location| location.range.start);
-            references
-        })
     }
 }

--- a/crates/service/src/features/rename.rs
+++ b/crates/service/src/features/rename.rs
@@ -104,21 +104,18 @@ impl LanguageService {
                 SymbolKind::BlockDef => {
                     symbol == *sym
                         || symbol_table
-                            .resolved
-                            .get(&symbol.key)
-                            .is_some_and(|def_key| *def_key == sym.key)
+                            .find_def(symbol.key)
+                            .is_some_and(|def_symbol| def_symbol.key == sym.key)
                 }
                 SymbolKind::BlockRef => {
                     if symbol.kind == SymbolKind::BlockDef {
                         symbol_table
-                            .resolved
-                            .get(&sym.key)
-                            .is_some_and(|def_key| *def_key == symbol.key)
-                    } else if let (Some(a), Some(b)) = (
-                        symbol_table.resolved.get(&symbol.key),
-                        symbol_table.resolved.get(&sym.key),
-                    ) {
-                        a == b
+                            .find_def(sym.key)
+                            .is_some_and(|def_symbol| def_symbol.key == symbol.key)
+                    } else if let (Some(a), Some(b)) =
+                        (symbol_table.find_def(symbol.key), symbol_table.find_def(sym.key))
+                    {
+                        a.key == b.key
                     } else {
                         false
                     }

--- a/crates/service/src/features/semantic_tokens.rs
+++ b/crates/service/src/features/semantic_tokens.rs
@@ -210,9 +210,8 @@ fn compute_token_modifier(
                     .map_or(0, |_| 1)
             }
             SymbolKind::GlobalRef | SymbolKind::TypeUse | SymbolKind::FieldRef => symbol_table
-                .resolved
-                .get(&symbol.key)
-                .and_then(|def_key| mutability::get_mutabilities(db, document).get(def_key))
+                .find_def(symbol.key)
+                .and_then(|def_symbol| mutability::get_mutabilities(db, document).get(&def_symbol.key))
                 .and_then(|mutability| mutability.mut_keyword)
                 .map_or(0, |_| 1),
             _ => 0,

--- a/crates/service/src/imex.rs
+++ b/crates/service/src/imex.rs
@@ -36,11 +36,11 @@ pub(crate) fn get_exports(db: &dyn salsa::Database, document: Document) -> Expor
             module.children().for_each(|module_field| {
                 if module_field.kind() == SyntaxKind::MODULE_FIELD_EXPORT {
                     if let Some(name) = module_field.children_by_kind(SyntaxKind::NAME).next()
-                        && let Some(def_key) = helpers::syntax::extract_index_from_export(module_field)
-                            .and_then(|index| symbol_table.resolved.get(&index.into()))
+                        && let Some(def_symbol) = helpers::syntax::extract_index_from_export(module_field)
+                            .and_then(|index| symbol_table.find_def(index.into()))
                     {
                         exports.push(Export {
-                            def_key: *def_key,
+                            def_key: def_symbol.key,
                             name: name.green().to_string(),
                             range: name.text_range(),
                         });

--- a/crates/service/src/mutability.rs
+++ b/crates/service/src/mutability.rs
@@ -114,7 +114,7 @@ pub(crate) fn get_mutation_actions(
                     SyntaxKind::EXTERN_IDX_GLOBAL => MutationActionKind::Export,
                     _ => return None,
                 };
-                let target = symbol_table.resolved.get(&symbol.key).copied();
+                let target = symbol_table.find_def(symbol.key).map(|symbol| symbol.key);
                 Some((symbol.key, MutationAction { target, kind }))
             }
             SymbolKind::FieldRef => {
@@ -124,7 +124,7 @@ pub(crate) fn get_mutation_actions(
                     "struct.set" => MutationActionKind::Set,
                     _ => return None,
                 };
-                let target = symbol_table.resolved.get(&symbol.key).copied();
+                let target = symbol_table.find_def(symbol.key).map(|symbol| symbol.key);
                 Some((symbol.key, MutationAction { target, kind }))
             }
             SymbolKind::TypeUse => {
@@ -142,7 +142,7 @@ pub(crate) fn get_mutation_actions(
                     }
                     _ => return None,
                 };
-                let target = symbol_table.resolved.get(&symbol.key).copied();
+                let target = symbol_table.find_def(symbol.key).map(|symbol| symbol.key);
                 Some((symbol.key, MutationAction { target, kind }))
             }
             _ => None,

--- a/crates/service/src/refactorings/inline_func_type.rs
+++ b/crates/service/src/refactorings/inline_func_type.rs
@@ -25,8 +25,8 @@ pub fn act(
 
     let index = type_use.index()?;
     let index = index.syntax();
-    let type_def_key = symbol_table.resolved.get(&SymbolKey::from(index))?;
-    let CompType::Func(func_type) = TypeDef::cast(type_def_key.to_node(root)?)?.sub_type()?.comp_type()? else {
+    let type_def = symbol_table.find_def(SymbolKey::from(index))?;
+    let CompType::Func(func_type) = TypeDef::cast(type_def.key.to_node(root)?)?.sub_type()?.comp_type()? else {
         return None;
     };
     func_type.syntax().children().next()?; // skip empty func type

--- a/crates/service/src/refactorings/merge_to_return_call.rs
+++ b/crates/service/src/refactorings/merge_to_return_call.rs
@@ -57,11 +57,10 @@ pub fn act(
         .ancestors()
         .find(|ancestor| ancestor.kind() == SyntaxKind::MODULE_FIELD_FUNC)?;
     if symbol_table
-        .resolved
-        .get(&SymbolKey::from(
+        .find_def(SymbolKey::from(
             &call_instr.children_by_kind(SyntaxKind::IMMEDIATE).next()?,
         ))
-        .is_none_or(|def_key| *def_key != SymbolKey::from(&func))
+        .is_none_or(|def_symbol| def_symbol.key != SymbolKey::from(&func))
     {
         return None;
     }

--- a/crates/service/src/types_analyzer/def_type.rs
+++ b/crates/service/src/types_analyzer/def_type.rs
@@ -31,8 +31,11 @@ pub(crate) fn get_def_types(db: &dyn salsa::Database, document: Document) -> Def
                 is_final = sub_type.keyword().is_none() || sub_type.final_keyword().is_some();
                 if let Some(index) = sub_type.indexes().next() {
                     let index = index.syntax();
-                    inherits = symbol_table.resolved.get(&SymbolKey::from(index)).and_then(|key| {
-                        Idx::from_green_for_ref(index.green(), db).map(|idx| Inherits { symbol: *key, idx })
+                    inherits = symbol_table.find_def(SymbolKey::from(index)).and_then(|symbol| {
+                        Idx::from_green_for_ref(index.green(), db).map(|idx| Inherits {
+                            symbol: symbol.key,
+                            idx,
+                        })
                     });
                 }
             }

--- a/crates/service/src/types_analyzer/instr.rs
+++ b/crates/service/src/types_analyzer/instr.rs
@@ -320,8 +320,8 @@ pub(crate) fn resolve_instr_sig<'db, 'bump>(
         "struct.new" => instr
             .children_by_kind(SyntaxKind::IMMEDIATE)
             .next()
-            .and_then(|immediate| ctx.symbol_table.resolved.get(&immediate.into()))
-            .and_then(|key| ctx.def_types.get(key))
+            .and_then(|immediate| ctx.symbol_table.find_def(immediate.into()))
+            .and_then(|symbol| ctx.def_types.get(&symbol.key))
             .map(|def_type| {
                 let params = if let CompositeType::Struct(fields) = &def_type.comp {
                     BumpVec::from_iter_in(
@@ -801,8 +801,8 @@ pub(crate) fn resolve_instr_sig<'db, 'bump>(
         "call_ref" | "return_call_ref" => instr
             .children_by_kind(SyntaxKind::IMMEDIATE)
             .next()
-            .and_then(|immediate| ctx.symbol_table.resolved.get(&immediate.into()))
-            .and_then(|key| ctx.def_types.get(key))
+            .and_then(|immediate| ctx.symbol_table.find_def(immediate.into()))
+            .and_then(|symbol| ctx.def_types.get(&symbol.key))
             .map(|def_type| {
                 let mut sig = def_type
                     .comp
@@ -825,8 +825,8 @@ pub(crate) fn resolve_instr_sig<'db, 'bump>(
         "cont.new" => instr
             .children_by_kind(SyntaxKind::IMMEDIATE)
             .next()
-            .and_then(|immediate| ctx.symbol_table.resolved.get(&immediate.into()))
-            .and_then(|key| ctx.def_types.get(key))
+            .and_then(|immediate| ctx.symbol_table.find_def(immediate.into()))
+            .and_then(|symbol| ctx.def_types.get(&symbol.key))
             .map(|def_type| {
                 let param = if let CompositeType::Cont(heap_ty) = &def_type.comp {
                     OperandType::Val(ValType::Ref(RefType {
@@ -855,13 +855,13 @@ pub(crate) fn resolve_instr_sig<'db, 'bump>(
             let mut immediates = instr.children_by_kind(SyntaxKind::IMMEDIATE);
             immediates
                 .next()
-                .and_then(|immediate| ctx.symbol_table.resolved.get(&immediate.into()))
-                .and_then(|key| ctx.def_types.get(key))
+                .and_then(|immediate| ctx.symbol_table.find_def(immediate.into()))
+                .and_then(|symbol| ctx.def_types.get(&symbol.key))
                 .zip(
                     immediates
                         .next()
-                        .and_then(|immediate| ctx.symbol_table.resolved.get(&immediate.into()))
-                        .and_then(|key| ctx.def_types.get(key)),
+                        .and_then(|immediate| ctx.symbol_table.find_def(immediate.into()))
+                        .and_then(|symbol| ctx.def_types.get(&symbol.key)),
                 )
                 .map(|(fst, snd)| {
                     let module = SymbolKey::from(ctx.module);
@@ -905,8 +905,8 @@ pub(crate) fn resolve_instr_sig<'db, 'bump>(
         "resume" => instr
             .children_by_kind(SyntaxKind::IMMEDIATE)
             .next()
-            .and_then(|immediate| ctx.symbol_table.resolved.get(&immediate.into()))
-            .and_then(|key| ctx.def_types.get(key))
+            .and_then(|immediate| ctx.symbol_table.find_def(immediate.into()))
+            .and_then(|symbol| ctx.def_types.get(&symbol.key))
             .and_then(|def_type| {
                 try_deref_cont_to_func(
                     ctx.symbol_table,

--- a/crates/service/src/types_analyzer/resolver.rs
+++ b/crates/service/src/types_analyzer/resolver.rs
@@ -59,9 +59,8 @@ pub(super) fn resolve_array_type_with_idx<'db>(
     immediate: AmberNode,
 ) -> Option<(Idx<'db>, Option<OperandType<'db>>)> {
     symbol_table
-        .resolved
-        .get(&immediate.into())
-        .and_then(|key| def_types.get(key))
+        .find_def(immediate.into())
+        .and_then(|symbol| def_types.get(&symbol.key))
         .map(|def_type| {
             if let CompositeType::Array(field) = &def_type.comp {
                 (

--- a/crates/service/src/types_analyzer/signature.rs
+++ b/crates/service/src/types_analyzer/signature.rs
@@ -31,8 +31,8 @@ impl<'db> NamedSig<'db> {
             let def_types = get_def_types(db, document);
             node.children_by_kind(SyntaxKind::INDEX)
                 .next()
-                .and_then(|idx| symbol_table.resolved.get(&idx.into()))
-                .and_then(|def_key| def_types.get(def_key))
+                .and_then(|idx| symbol_table.find_def(idx.into()))
+                .and_then(|def_symbol| def_types.get(&def_symbol.key))
                 .and_then(|def_type| def_type.comp.as_func().cloned())
                 .unwrap_or_default()
         }
@@ -123,8 +123,8 @@ impl<'db> Sig<'db> {
             let def_types = get_def_types(db, document);
             node.children_by_kind(SyntaxKind::INDEX)
                 .next()
-                .and_then(|idx| symbol_table.resolved.get(&idx.into()))
-                .and_then(|def_key| def_types.get(def_key))
+                .and_then(|idx| symbol_table.find_def(idx.into()))
+                .and_then(|def_symbol| def_types.get(&def_symbol.key))
                 .and_then(|def_type| def_type.comp.as_func())
                 .map(|sig| Self {
                     params: sig.params.iter().map(|(ty, _)| ty.clone()).collect(),

--- a/crates/service/tests/document_highlight/mod.rs
+++ b/crates/service/tests/document_highlight/mod.rs
@@ -627,7 +627,7 @@ fn block_ref_undefined() {
     let mut service = LanguageService::default();
     service.commit(uri.clone(), source.into());
     let response = service.document_highlight(create_params(uri, 7, 18));
-    assert!(response.is_none());
+    assert!(response.unwrap().is_empty());
 }
 
 #[test]

--- a/crates/service/tests/document_highlight/snapshots/features__document_highlight__block.snap
+++ b/crates/service/tests/document_highlight/snapshots/features__document_highlight__block.snap
@@ -33,11 +33,11 @@ expression: response
     "range": {
       "start": {
         "line": 6,
-        "character": 21
+        "character": 19
       },
       "end": {
         "line": 6,
-        "character": 23
+        "character": 20
       }
     },
     "kind": 2
@@ -46,11 +46,11 @@ expression: response
     "range": {
       "start": {
         "line": 6,
-        "character": 19
+        "character": 21
       },
       "end": {
         "line": 6,
-        "character": 20
+        "character": 23
       }
     },
     "kind": 2

--- a/crates/service/tests/document_highlight/snapshots/features__document_highlight__block_ref_ident.snap
+++ b/crates/service/tests/document_highlight/snapshots/features__document_highlight__block_ref_ident.snap
@@ -20,11 +20,11 @@ expression: response
     "range": {
       "start": {
         "line": 7,
-        "character": 24
+        "character": 17
       },
       "end": {
         "line": 7,
-        "character": 26
+        "character": 18
       }
     },
     "kind": 2
@@ -33,11 +33,11 @@ expression: response
     "range": {
       "start": {
         "line": 7,
-        "character": 17
+        "character": 24
       },
       "end": {
         "line": 7,
-        "character": 18
+        "character": 26
       }
     },
     "kind": 2

--- a/crates/service/tests/document_highlight/snapshots/features__document_highlight__block_ref_int.snap
+++ b/crates/service/tests/document_highlight/snapshots/features__document_highlight__block_ref_int.snap
@@ -19,12 +19,12 @@ expression: response
   {
     "range": {
       "start": {
-        "line": 7,
-        "character": 21
+        "line": 5,
+        "character": 15
       },
       "end": {
-        "line": 7,
-        "character": 23
+        "line": 5,
+        "character": 16
       }
     },
     "kind": 2
@@ -45,12 +45,12 @@ expression: response
   {
     "range": {
       "start": {
-        "line": 5,
-        "character": 15
+        "line": 7,
+        "character": 21
       },
       "end": {
-        "line": 5,
-        "character": 16
+        "line": 7,
+        "character": 23
       }
     },
     "kind": 2


### PR DESCRIPTION
For a 408589102 byte WAT file, this can reduce about 164 ~ 180 MB memory usage.