### PR TITLE
perf(parser): reuse parsed trivias

### DIFF
--- a/crates/parser/src/parser2/helpers.rs
+++ b/crates/parser/src/parser2/helpers.rs
@@ -1,4 +1,4 @@
-use super::{GreenElement, Parser, green, lexer::Token};
+use super::{GreenElement, Parser, builder::Checkpoint, green, lexer::Token};
 use crate::error::{Message, SyntaxError};
 use std::ops::ControlFlow;
 use wat_syntax::{GreenToken, SyntaxKind, TextRange, TextSize};
@@ -17,6 +17,7 @@ impl<'s> Parser<'s, '_> {
         if self.parse_errors() {
             true
         } else {
+            self.recycle_trivias(checkpoint_before_trivias, checkpoint_after_trivias);
             self.reset(checkpoint_before_trivias);
             false
         }
@@ -36,6 +37,7 @@ impl<'s> Parser<'s, '_> {
                 self.report_error_token(&token, Message::UnexpectedToken);
                 self.add_child(token);
             } else {
+                self.recycle_trivias(checkpoint_before_trivias, checkpoint_after_trivias);
                 self.reset(checkpoint_before_trivias);
                 return false;
             }
@@ -51,12 +53,14 @@ impl<'s> Parser<'s, '_> {
         result
     }
     pub(super) fn try_parse_with_trivias<T>(&mut self, parser: impl FnOnce(&mut Self) -> Option<T>) -> Option<T> {
-        let checkpoint = self.checkpoint();
+        let checkpoint_before_trivias = self.checkpoint();
         self.parse_trivias();
+        let checkpoint_after_trivias = self.checkpoint();
         match parser(self) {
             Some(result) => Some(result),
             None => {
-                self.reset(checkpoint);
+                self.recycle_trivias(checkpoint_before_trivias, checkpoint_after_trivias);
+                self.reset(checkpoint_before_trivias);
                 None
             }
         }
@@ -77,13 +81,15 @@ impl<'s> Parser<'s, '_> {
     /// "Eat" a token with processing the trivias before the token.
     /// After parsed, trivias and token will be added to `children`.
     pub(super) fn eat(&mut self, kind: SyntaxKind) -> bool {
-        let checkpoint = self.checkpoint();
+        let checkpoint_before_trivias = self.checkpoint();
         self.parse_trivias();
+        let checkpoint_after_trivias = self.checkpoint();
         if let Some(token) = self.lexer.eat(kind) {
             self.add_child(token);
             true
         } else {
-            self.reset(checkpoint);
+            self.recycle_trivias(checkpoint_before_trivias, checkpoint_after_trivias);
+            self.reset(checkpoint_before_trivias);
             false
         }
     }
@@ -95,8 +101,9 @@ impl<'s> Parser<'s, '_> {
             self.add_child(token);
             let mut stack = 1u16;
             loop {
-                let checkpoint = self.checkpoint();
+                let checkpoint_before_trivias = self.checkpoint();
                 self.parse_trivias();
+                let checkpoint_after_trivias = self.checkpoint();
                 if let Some(mut token) = self.lexer.eat(SyntaxKind::L_PAREN) {
                     token.kind = SyntaxKind::ERROR;
                     self.report_error_token(&token, Message::UnexpectedToken);
@@ -114,7 +121,8 @@ impl<'s> Parser<'s, '_> {
                     self.report_error_token(&token, Message::UnexpectedToken);
                     self.add_child(token);
                 } else {
-                    self.reset(checkpoint);
+                    self.recycle_trivias(checkpoint_before_trivias, checkpoint_after_trivias);
+                    self.reset(checkpoint_before_trivias);
                     break;
                 }
             }
@@ -129,40 +137,46 @@ impl<'s> Parser<'s, '_> {
     }
 
     pub(super) fn parse_trivias(&mut self) {
-        while let Some(token) = self.lexer.trivia() {
-            match token.kind {
-                SyntaxKind::WHITESPACE => {
-                    if token.text.as_bytes() == b" " {
-                        self.add_child(green::SINGLE_SPACE.clone());
-                    } else if let Some(rest) = token.text.strip_prefix('\n')
-                        && let ControlFlow::Continue(count) = rest.bytes().try_fold(0usize, |count, b| {
-                            if count > 1000 || b != b' ' {
-                                ControlFlow::Break(())
-                            } else {
-                                ControlFlow::Continue(count + 1)
-                            }
-                        })
-                        && count.is_multiple_of(2)
-                        && let Some(token) = green::INDENT.get(count / 2)
-                    {
-                        self.add_child(token.clone());
-                    } else {
+        if let Some(checkpoint) = self.reusable_trivias.1.take() {
+            self.reset(checkpoint);
+            self.elements.append(&mut self.reusable_trivias.0);
+        } else {
+            while let Some(token) = self.lexer.trivia() {
+                match token.kind {
+                    SyntaxKind::WHITESPACE => {
+                        if token.text.as_bytes() == b" " {
+                            self.add_child(green::SINGLE_SPACE.clone());
+                        } else if let Some(rest) = token.text.strip_prefix('\n')
+                            && let ControlFlow::Continue(count) = rest.bytes().try_fold(0usize, |count, b| {
+                                if count > 1000 || b != b' ' {
+                                    ControlFlow::Break(())
+                                } else {
+                                    ControlFlow::Continue(count + 1)
+                                }
+                            })
+                            && count.is_multiple_of(2)
+                            && let Some(token) = green::INDENT.get(count / 2)
+                        {
+                            self.add_child(token.clone());
+                        } else {
+                            self.add_child(token);
+                        }
+                    }
+                    SyntaxKind::LINE_COMMENT | SyntaxKind::BLOCK_COMMENT if token.text.len() < 16 => {
+                        let token = self.intern_token(token);
                         self.add_child(token);
                     }
+                    _ => self.add_child(token),
                 }
-                SyntaxKind::LINE_COMMENT | SyntaxKind::BLOCK_COMMENT if token.text.len() < 16 => {
-                    let token = self.intern_token(token);
-                    self.add_child(token);
-                }
-                _ => self.add_child(token),
             }
         }
     }
 
     pub(super) fn expect_right_paren(&mut self) {
         loop {
-            let checkpoint = self.checkpoint();
+            let checkpoint_before_trivias = self.checkpoint();
             self.parse_trivias();
+            let checkpoint_after_trivias = self.checkpoint();
             if self.lexer.next(SyntaxKind::R_PAREN).is_some() {
                 self.add_child(green::R_PAREN.clone());
                 return;
@@ -170,7 +184,7 @@ impl<'s> Parser<'s, '_> {
             if let Some(token) = self.lexer.peek(SyntaxKind::L_PAREN) {
                 // a trick:
                 // if there're newlines before next left paren, we should exit from current parsing node
-                if let Some(slice) = self.elements.get(checkpoint.elements..)
+                if let Some(slice) = self.elements.get(checkpoint_before_trivias.elements..)
                     && slice.iter().any(|node_or_token| {
                         if let GreenElement::Token(token) = node_or_token {
                             token.text().contains('\n')
@@ -179,13 +193,15 @@ impl<'s> Parser<'s, '_> {
                         }
                     })
                 {
-                    self.reset(checkpoint);
+                    self.recycle_trivias(checkpoint_before_trivias, checkpoint_after_trivias);
+                    self.reset(checkpoint_before_trivias);
                     self.report_error_token(&token, Message::Char(')'));
                     return;
                 }
             }
             if !self.parse_errors() {
-                self.reset(checkpoint);
+                self.recycle_trivias(checkpoint_before_trivias, checkpoint_after_trivias);
+                self.reset(checkpoint_before_trivias);
                 let start = self.source.len();
                 self.errors.push(SyntaxError {
                     range: TextRange::new(TextSize::new(start as u32), TextSize::new(start as u32)),
@@ -233,6 +249,14 @@ impl<'s> Parser<'s, '_> {
             .entry(token.text)
             .or_insert_with(|| GreenToken::new(token.kind, token.text))
             .clone()
+    }
+
+    fn recycle_trivias(&mut self, before_trivias: Checkpoint<'s>, after_trivias: Checkpoint<'s>) {
+        self.elements.truncate(after_trivias.elements);
+        self.reusable_trivias
+            .0
+            .extend(self.elements.drain(before_trivias.elements..));
+        self.reusable_trivias.1 = Some(after_trivias);
     }
 }
 

--- a/crates/parser/src/parser2/instr.rs
+++ b/crates/parser/src/parser2/instr.rs
@@ -249,8 +249,8 @@ impl<'s> Parser<'s, '_> {
                 ..,
             ] => self
                 .try_parse(Self::parse_ref_type_detailed)
-                .or_else(|| self.try_parse(Self::parse_type_use))
                 .or_else(|| self.try_parse(Self::parse_on_clause))
+                .or_else(|| self.try_parse(Self::parse_type_use))
                 .map(|child| GreenNode::new(IMMEDIATE, [child.into()])),
             [b'"', ..] => self
                 .lexer

--- a/crates/parser/src/parser2/mod.rs
+++ b/crates/parser/src/parser2/mod.rs
@@ -1,4 +1,4 @@
-use self::lexer::Lexer;
+use self::{builder::Checkpoint, lexer::Lexer};
 use crate::error::SyntaxError;
 use bumpalo::{Bump, collections::Vec as BumpVec};
 use hashbrown::HashMap;
@@ -177,6 +177,7 @@ struct Parser<'s, 'bump> {
     errors: Vec<SyntaxError>,
     elements: BumpVec<'bump, GreenElement>,
     token_interner: HashMap<&'s str, GreenToken, FxBuildHasher, &'bump Bump>,
+    reusable_trivias: (BumpVec<'bump, GreenElement>, Option<Checkpoint<'s>>),
 }
 
 impl<'s, 'bump> Parser<'s, 'bump> {
@@ -187,6 +188,7 @@ impl<'s, 'bump> Parser<'s, 'bump> {
             errors: Vec::new(),
             elements: BumpVec::with_capacity_in(16, bump),
             token_interner: HashMap::with_capacity_and_hasher_in(16, FxBuildHasher, bump),
+            reusable_trivias: (BumpVec::with_capacity_in(4, bump), None),
         }
     }
 


### PR DESCRIPTION
For small input, there may be regression. But for large input, this can significantly improve performance.

Before:

```
parser/900 bytes        time:   [6.3401 µs 6.3526 µs 6.3652 µs]                              
                        thrpt:  [144.73 MiB/s 145.02 MiB/s 145.30 MiB/s]
                 change:
                        time:   [+1.0634% +1.3065% +1.5360%] (p = 0.00 < 0.05)
                        thrpt:  [-1.5128% -1.2896% -1.0522%]
                        Performance has regressed.
Benchmarking parser/swc (408589102 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 121.1s, or reduce sample count to 10.
parser/swc (408589102 bytes)
                        time:   [1.2092 s 1.2103 s 1.2114 s]
                        thrpt:  [321.67 MiB/s 321.95 MiB/s 322.24 MiB/s]
                 change:
                        time:   [+0.9266% +1.0804% +1.2322%] (p = 0.00 < 0.05)
                        thrpt:  [-1.2172% -1.0689% -0.9181%]
                        Change within noise threshold.
Benchmarking parser/wat_service (88656525 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 18.0s, or reduce sample count to 20.
parser/wat_service (88656525 bytes)
                        time:   [178.52 ms 178.79 ms 179.06 ms]
                        thrpt:  [472.19 MiB/s 472.90 MiB/s 473.61 MiB/s]
                 change:
                        time:   [+0.5831% +0.8032% +1.0460%] (p = 0.00 < 0.05)
                        thrpt:  [-1.0352% -0.7968% -0.5797%]
                        Change within noise threshold.
Benchmarking parser/dprint_plugin_malva (18876854 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.3s, or reduce sample count to 60.
parser/dprint_plugin_malva (18876854 bytes)
                        time:   [72.273 ms 72.398 ms 72.520 ms]
                        thrpt:  [248.24 MiB/s 248.66 MiB/s 249.09 MiB/s]
                 change:
                        time:   [+0.5613% +0.7972% +1.0337%] (p = 0.00 < 0.05)
                        thrpt:  [-1.0232% -0.7909% -0.5582%]
                        Change within noise threshold.
```

After:

```
parser/900 bytes        time:   [6.6073 µs 6.6170 µs 6.6264 µs]
                        thrpt:  [139.03 MiB/s 139.22 MiB/s 139.43 MiB/s]
                 change:
                        time:   [+3.8547% +4.1099% +4.3650%] (p = 0.00 < 0.05)
                        thrpt:  [-4.1825% -3.9477% -3.7117%]
                        Performance has regressed.
Benchmarking parser/swc (408589102 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 96.5s, or reduce sample count to 10.
parser/swc (408589102 bytes)
                        time:   [960.92 ms 961.76 ms 962.61 ms]
                        thrpt:  [404.80 MiB/s 405.16 MiB/s 405.51 MiB/s]
                 change:
                        time:   [-20.636% -20.536% -20.444%] (p = 0.00 < 0.05)
                        thrpt:  [+25.698% +25.844% +26.002%]
                        Performance has improved.
Benchmarking parser/wat_service (88656525 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 14.3s, or reduce sample count to 30.
parser/wat_service (88656525 bytes)
                        time:   [142.22 ms 142.43 ms 142.66 ms]
                        thrpt:  [592.65 MiB/s 593.61 MiB/s 594.49 MiB/s]
                 change:
                        time:   [-20.514% -20.335% -20.160%] (p = 0.00 < 0.05)
                        thrpt:  [+25.250% +25.526% +25.808%]
                        Performance has improved.
Benchmarking parser/dprint_plugin_malva (18876854 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.3s, or reduce sample count to 70.
parser/dprint_plugin_malva (18876854 bytes)
                        time:   [62.500 ms 62.605 ms 62.716 ms]
                        thrpt:  [287.05 MiB/s 287.55 MiB/s 288.04 MiB/s]
                 change:
                        time:   [-13.731% -13.526% -13.304%] (p = 0.00 < 0.05)
                        thrpt:  [+15.346% +15.642% +15.917%]
                        Performance has improved.
```