### PR TITLE
perf(parser): "early return" for common cases when parsing immediate

### DIFF
--- a/crates/parser/src/parser2/instr.rs
+++ b/crates/parser/src/parser2/instr.rs
@@ -220,7 +220,12 @@ impl<'s> Parser<'s, '_> {
             [b'a', b'l', ..] | [b'o', ..] => self
                 .parse_mem_arg()
                 .map(|child| GreenNode::new(IMMEDIATE, [child.into()])),
-            [b'e', b'n', b'd', ..] | [b'e', b'l', b's', b'e', ..] => None,
+            // perf: "early return" by checking bytes sequence characteristic:
+            // - keyword `end` or `else`
+            // - instruction name that starts with `{i,f}{32,64}.`
+            // - instruction name `call`
+            // - keyword `if`
+            [b'e', b'n' | b'l', ..] | [b'i' | b'f', _, _, b'.', ..] | [b'c', b'a', ..] | [b'i', b'f', ..] => None,
             [b'i', b'n', ..] | [b'n', b'a', ..] => self
                 .lexer
                 .eat(FLOAT)
@@ -230,14 +235,13 @@ impl<'s> Parser<'s, '_> {
                     }
                 })
                 .map(|token| GreenNode::new(IMMEDIATE, [token.into()])),
-            [b'a' | b'c' | b'e' | b'f' | b'i' | b'n' | b's', ..] => self
+            [b'i', b'8', b'x', ..] | [b'i' | b'f', _, _, b'x', ..] => self
                 .lexer
                 .eat(SHAPE_DESCRIPTOR)
-                .map(|token| GreenNode::new(IMMEDIATE, [token.into()]))
-                .or_else(|| {
-                    self.try_parse(Self::parse_ref_type)
-                        .map(|child| GreenNode::new(IMMEDIATE, [child.into()]))
-                })
+                .map(|token| GreenNode::new(IMMEDIATE, [token.into()])),
+            [b'a' | b'c' | b'e' | b'f' | b'i' | b'n' | b's', ..] => self
+                .try_parse(Self::parse_ref_type)
+                .map(|child| GreenNode::new(IMMEDIATE, [child.into()]))
                 .or_else(|| {
                     self.try_parse(Self::parse_heap_type::<true>)
                         .map(|child| GreenNode::new(IMMEDIATE, [child]))


### PR DESCRIPTION
This optimizes performance for large input.

Before:

```
parser/900 bytes        time:   [6.6816 µs 6.7014 µs 6.7206 µs]                              
                        thrpt:  [137.08 MiB/s 137.47 MiB/s 137.88 MiB/s]
Benchmarking parser/swc (408589102 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 98.0s, or reduce sample count to 10.
parser/swc (408589102 bytes)                                                                            
                        time:   [993.37 ms 994.43 ms 995.45 ms]
                        thrpt:  [391.44 MiB/s 391.84 MiB/s 392.26 MiB/s]
Benchmarking parser/wat_service (88656525 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 14.7s, or reduce sample count to 30.
parser/wat_service (88656525 bytes)                                                                            
                        time:   [146.44 ms 146.57 ms 146.70 ms]
                        thrpt:  [576.33 MiB/s 576.85 MiB/s 577.37 MiB/s]
Benchmarking parser/dprint_plugin_malva (18876854 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.6s, or reduce sample count to 70.
parser/dprint_plugin_malva (18876854 bytes)                                                                            
                        time:   [65.270 ms 65.340 ms 65.412 ms]
                        thrpt:  [275.22 MiB/s 275.52 MiB/s 275.81 MiB/s]
```

After:

```
parser/900 bytes        time:   [6.6763 µs 6.6921 µs 6.7092 µs]                              
                        thrpt:  [137.31 MiB/s 137.66 MiB/s 137.99 MiB/s]
                 change:
                        time:   [-0.3734% -0.1105% +0.1643%] (p = 0.43 > 0.05)
                        thrpt:  [-0.1641% +0.1106% +0.3748%]
                        No change in performance detected.
Benchmarking parser/swc (408589102 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 91.2s, or reduce sample count to 10.
parser/swc (408589102 bytes)                                                                            
                        time:   [908.35 ms 909.07 ms 909.82 ms]
                        thrpt:  [428.28 MiB/s 428.64 MiB/s 428.98 MiB/s]
                 change:
                        time:   [-8.7074% -8.5833% -8.4643%] (p = 0.00 < 0.05)
                        thrpt:  [+9.2470% +9.3892% +9.5379%]
                        Performance has improved.
Benchmarking parser/wat_service (88656525 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 13.4s, or reduce sample count to 30.
parser/wat_service (88656525 bytes)                                                                            
                        time:   [133.22 ms 133.42 ms 133.62 ms]
                        thrpt:  [632.75 MiB/s 633.71 MiB/s 634.65 MiB/s]
                 change:
                        time:   [-9.1189% -8.9721% -8.8026%] (p = 0.00 < 0.05)
                        thrpt:  [+9.6523% +9.8565% +10.034%]
                        Performance has improved.
Benchmarking parser/dprint_plugin_malva (18876854 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, or reduce sample count to 80.
parser/dprint_plugin_malva (18876854 bytes)                                                                            
                        time:   [58.983 ms 59.105 ms 59.231 ms]
                        thrpt:  [303.93 MiB/s 304.58 MiB/s 305.21 MiB/s]
                 change:
                        time:   [-9.7649% -9.5425% -9.3366%] (p = 0.00 < 0.05)
                        thrpt:  [+10.298% +10.549% +10.822%]
                        Performance has improved.
```