### PR TITLE
perf(parser): compare string instead of counting spaces manually

### DIFF
--- a/crates/parser/src/parser2/green.rs
+++ b/crates/parser/src/parser2/green.rs
@@ -7,7 +7,7 @@ pub static R_PAREN: LazyLock<GreenElement> = LazyLock::new(|| GreenToken::new(Sy
 pub static EQ: LazyLock<GreenElement> = LazyLock::new(|| GreenToken::new(SyntaxKind::EQ, "=").into());
 
 pub static SINGLE_SPACE: LazyLock<GreenElement> = LazyLock::new(|| GreenToken::new(SyntaxKind::WHITESPACE, " ").into());
-pub static INDENT: LazyLock<Vec<GreenElement>> = LazyLock::new(|| {
+pub static INDENT: LazyLock<Vec<GreenToken>> = LazyLock::new(|| {
     (0..=500)
         .map(|i| {
             let mut s = String::with_capacity(i * 2 + 1);
@@ -15,7 +15,7 @@ pub static INDENT: LazyLock<Vec<GreenElement>> = LazyLock::new(|| {
             for _ in 0..i {
                 s.push_str("  ");
             }
-            GreenToken::new(SyntaxKind::WHITESPACE, &s).into()
+            GreenToken::new(SyntaxKind::WHITESPACE, &s)
         })
         .collect()
 });

--- a/crates/parser/src/parser2/helpers.rs
+++ b/crates/parser/src/parser2/helpers.rs
@@ -1,6 +1,5 @@
 use super::{GreenElement, Parser, builder::Checkpoint, green, lexer::Token};
 use crate::error::{Message, SyntaxError};
-use std::ops::ControlFlow;
 use wat_syntax::{GreenToken, SyntaxKind, TextRange, TextSize};
 
 impl<'s> Parser<'s, '_> {
@@ -147,17 +146,13 @@ impl<'s> Parser<'s, '_> {
                         if token.text.as_bytes() == b" " {
                             self.add_child(green::SINGLE_SPACE.clone());
                         } else if let Some(rest) = token.text.strip_prefix('\n')
-                            && let ControlFlow::Continue(count) = rest.bytes().try_fold(0usize, |count, b| {
-                                if count > 1000 || b != b' ' {
-                                    ControlFlow::Break(())
-                                } else {
-                                    ControlFlow::Continue(count + 1)
-                                }
-                            })
-                            && count.is_multiple_of(2)
-                            && let Some(token) = green::INDENT.get(count / 2)
+                            && let Some(green_token) = green::INDENT.get(rest.len() / 2)
+                            && green_token.text() == token.text
                         {
-                            self.add_child(token.clone());
+                            // fun perf tip:
+                            // string comparison instead of manually counting spaces (even SIMD) above
+                            // can be significantly faster
+                            self.add_child(green_token.clone());
                         } else if token.text.len() < 4 {
                             let token = self.intern_token(token);
                             self.add_child(token);

--- a/crates/parser/src/parser2/mod.rs
+++ b/crates/parser/src/parser2/mod.rs
@@ -206,6 +206,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn tab_indent() {
+        let text = "(module\n\t(func\n\t\tnop))";
+        assert_eq!(parse(text).0.to_string(), text);
+    }
+
+    #[test]
+    fn crlf() {
+        let text = "(module\r\n  (func\r\n    nop))";
+        assert_eq!(parse(text).0.to_string(), text);
+    }
+
+    #[test]
+    fn odd_indent() {
+        let text = "(module\n (func\n   nop))";
+        assert_eq!(parse(text).0.to_string(), text);
+    }
+
+    #[test]
     fn valid_right_paren_in_parse_as() {
         let (_, errors) = parse_as(SyntaxKind::MODULE_FIELD_FUNC, "(func\n    \n  )").unwrap();
         assert!(errors.is_empty());


### PR DESCRIPTION
Fun fact: this optimization can be even faster than manual SIMD.

Here's the result tested on Apple M4.

Before:

```
parser/900 bytes        time:   [6.5802 µs 6.5975 µs 6.6153 µs]                              
                        thrpt:  [139.26 MiB/s 139.64 MiB/s 140.00 MiB/s]
Benchmarking parser/swc (408589102 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 88.2s, or reduce sample count to 10.
parser/swc (408589102 bytes)                                                                            
                        time:   [897.66 ms 899.03 ms 900.36 ms]
                        thrpt:  [432.79 MiB/s 433.43 MiB/s 434.08 MiB/s]
Benchmarking parser/wat_service (88656525 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 13.5s, or reduce sample count to 30.
parser/wat_service (88656525 bytes)                                                                            
                        time:   [132.49 ms 132.72 ms 132.96 ms]
                        thrpt:  [635.91 MiB/s 637.04 MiB/s 638.15 MiB/s]
Benchmarking parser/dprint_plugin_malva (18876854 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, or reduce sample count to 80.
parser/dprint_plugin_malva (18876854 bytes)                                                                            
                        time:   [58.858 ms 58.990 ms 59.126 ms]
                        thrpt:  [304.47 MiB/s 305.17 MiB/s 305.86 MiB/s]
```

After:

```
parser/900 bytes        time:   [6.7062 µs 6.7228 µs 6.7422 µs]                              
                        thrpt:  [136.64 MiB/s 137.03 MiB/s 137.37 MiB/s]
                 change:
                        time:   [+1.7616% +3.3191% +5.8285%] (p = 0.00 < 0.05)
                        thrpt:  [-5.5075% -3.2125% -1.7311%]
                        Performance has regressed.
Benchmarking parser/swc (408589102 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 76.4s, or reduce sample count to 10.
parser/swc (408589102 bytes)                                                                            
                        time:   [762.95 ms 763.63 ms 764.36 ms]
                        thrpt:  [509.79 MiB/s 510.27 MiB/s 510.73 MiB/s]
                 change:
                        time:   [-15.207% -15.060% -14.912%] (p = 0.00 < 0.05)
                        thrpt:  [+17.526% +17.730% +17.934%]
                        Performance has improved.
Benchmarking parser/wat_service (88656525 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 11.2s, or reduce sample count to 40.
parser/wat_service (88656525 bytes)                                                                            
                        time:   [110.39 ms 110.54 ms 110.69 ms]
                        thrpt:  [763.85 MiB/s 764.89 MiB/s 765.90 MiB/s]
                 change:
                        time:   [-16.893% -16.715% -16.532%] (p = 0.00 < 0.05)
                        thrpt:  [+19.806% +20.069% +20.327%]
                        Performance has improved.
Benchmarking parser/dprint_plugin_malva (18876854 bytes): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.5s, or reduce sample count to 90.
parser/dprint_plugin_malva (18876854 bytes)                                                                            
                        time:   [54.160 ms 54.230 ms 54.303 ms]
                        thrpt:  [331.52 MiB/s 331.96 MiB/s 332.39 MiB/s]
                 change:
                        time:   [-8.3188% -8.0693% -7.8325%] (p = 0.00 < 0.05)
                        thrpt:  [+8.4981% +8.7776% +9.0736%]
                        Performance has improved.
```